### PR TITLE
Rename `BlazorTemplater` class to `Templater`. Fixes #4

### DIFF
--- a/BlazorTemplater.ConsoleApp/BlazorTemplater.ConsoleApp.csproj
+++ b/BlazorTemplater.ConsoleApp/BlazorTemplater.ConsoleApp.csproj
@@ -6,12 +6,10 @@
     <RazorLangVersion>3.0</RazorLangVersion>
   </PropertyGroup>
 
-
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components" Version="3.1.14" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="3.1.14" />
   </ItemGroup>
-
 
   <ItemGroup>
     <ProjectReference Include="..\BlazorTemplater\BlazorTemplater.csproj" />

--- a/BlazorTemplater.ConsoleApp/Program.cs
+++ b/BlazorTemplater.ConsoleApp/Program.cs
@@ -4,12 +4,12 @@ namespace BlazorTemplater.ConsoleApp
 {
     class Program
     {
-        static void Main(string[] args)
+        static void Main()
         {
             Console.WriteLine("Rendering Sample.razor to HTML..");
 
-            var renderer = new BlazorTemplater();
-            var html = renderer.RenderComponent<Sample>();
+            var templater = new Templater();
+            var html = templater.RenderComponent<Sample>();
 
             Console.WriteLine(html);
         }

--- a/BlazorTemplater.Library/BlazorTemplater.Library.csproj
+++ b/BlazorTemplater.Library/BlazorTemplater.Library.csproj
@@ -9,7 +9,6 @@
     <Product>BlazorTemplater</Product>
   </PropertyGroup>
 
-
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components" Version="3.1.14" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="3.1.14" />

--- a/BlazorTemplater.Library/CodeBehind.razor
+++ b/BlazorTemplater.Library/CodeBehind.razor
@@ -1,0 +1,1 @@
+﻿<p>Yes @Name, we can use code-behind files with @App</p>

--- a/BlazorTemplater.Library/CodeBehind.razor.cs
+++ b/BlazorTemplater.Library/CodeBehind.razor.cs
@@ -1,0 +1,15 @@
+﻿using Microsoft.AspNetCore.Components;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BlazorTemplater.Library
+{
+    public partial class CodeBehind : ComponentBase
+    {
+        [Parameter] public string Name { get; set; }
+        [Parameter] public string App { get; set; }
+    }
+}

--- a/BlazorTemplater.Library/ServiceInjection.razor
+++ b/BlazorTemplater.Library/ServiceInjection.razor
@@ -1,4 +1,4 @@
-﻿@inject ITestService testService;
+﻿@inject ITestService testService
 <p>If you add @A and @B you get @testService.Add(A,B)</p>
 @code
 {

--- a/BlazorTemplater.Tests/BlazorTemplater_Tests.cs
+++ b/BlazorTemplater.Tests/BlazorTemplater_Tests.cs
@@ -13,7 +13,7 @@ namespace BlazorTemplater.Tests
         [TestMethod]
         public void Ctor_Test()
         {
-            var templater = new BlazorTemplater();
+            var templater = new Templater();
             Assert.IsNotNull(templater);
         }
 
@@ -29,8 +29,8 @@ namespace BlazorTemplater.Tests
         {
             const string expected = @"<b>Jan 1st is 2021-01-01</b>";
 
-            var renderer = new BlazorTemplater();
-            var actual = renderer.RenderComponent<Simple>();
+            var templater = new Templater();
+            var actual = templater.RenderComponent<Simple>();
 
             Console.WriteLine(actual);
             Assert.AreEqual(expected, actual);
@@ -49,7 +49,7 @@ namespace BlazorTemplater.Tests
             // expected output
             const string expected = "<p>Steve Sanderson is awesome!</p>";
 
-            var renderer = new BlazorTemplater();
+            var templater = new Templater();
             var model = new TestModel()
             {
                 Name = "Steve Sanderson",
@@ -59,7 +59,7 @@ namespace BlazorTemplater.Tests
             {
                 { nameof(Parameters.Model), model }
             };
-            var html = renderer.RenderComponent<Parameters>(parameters);
+            var html = templater.RenderComponent<Parameters>(parameters);
 
             // trim leading space and trailing CRLF from output
             var actual = html.Trim();
@@ -77,7 +77,7 @@ namespace BlazorTemplater.Tests
             // expected output
             const string expected = "<p>Safia &amp; Pranav are awesome too!</p>";
 
-            var renderer = new BlazorTemplater();
+            var templater = new Templater();
             var model = new TestModel()
             {
                 Name = "Safia & Pranav",
@@ -87,7 +87,7 @@ namespace BlazorTemplater.Tests
             {
                 { nameof(Parameters.Model), model }
             };
-            var html = renderer.RenderComponent<Parameters>(parameters);
+            var html = templater.RenderComponent<Parameters>(parameters);
 
             // trim leading space and trailing CRLF from output
             var actual = html.Trim();
@@ -105,8 +105,8 @@ namespace BlazorTemplater.Tests
             // expected output
             const string expected = "<p>No model!</p>";
 
-            var renderer = new BlazorTemplater();
-            var html = renderer.RenderComponent<Parameters>();
+            var templater = new Templater();
+            var html = templater.RenderComponent<Parameters>();
 
             // trim leading space and trailing CRLF from output
             var actual = html.Trim();
@@ -125,12 +125,12 @@ namespace BlazorTemplater.Tests
         [TestMethod]
         public void RenderComponent_Error_Test()
         {
-            var renderer = new BlazorTemplater();
+            var templater = new Templater();
 
             // we should get a NullReferenceException thrown as Model parameter is not set
             Assert.ThrowsException<NullReferenceException>(() =>
             {
-                _ = renderer.RenderComponent<ErrorTest>();
+                _ = templater.RenderComponent<ErrorTest>();
             });
         }
 
@@ -150,16 +150,16 @@ namespace BlazorTemplater.Tests
             const int c = a + b;
             string expected = $"<p>If you add {a} and {b} you get {c}</p>";
 
-            // create a renderer and register an ITestService. The service adds values
-            var renderer = new BlazorTemplater();
-            renderer.AddService<ITestService>(new TestService());
+            // create a templater and register an ITestService. The service adds values
+            var templater = new Templater();
+            templater.AddService<ITestService>(new TestService());
 
             var parameters = new Dictionary<string, object>()
             {
                 { nameof(ServiceInjection.A), a },
                 { nameof(ServiceInjection.B), b }
             };
-            var actual = renderer.RenderComponent<ServiceInjection>(parameters);
+            var actual = templater.RenderComponent<ServiceInjection>(parameters);
 
             Console.WriteLine(actual);
             Assert.AreEqual(expected, actual);
@@ -180,7 +180,7 @@ namespace BlazorTemplater.Tests
             // on Windows the string contains \r\n and on unix it's just \n
             string expected = $"<b>Jan 1st is 2021-01-01</b>{Environment.NewLine}    <p>Dan Roth is cool!</p>";
 
-            var renderer = new BlazorTemplater();
+            var templater = new Templater();
             var model = new TestModel()
             {
                 Name = "Dan Roth",
@@ -190,7 +190,7 @@ namespace BlazorTemplater.Tests
             {
                 { nameof(Parameters.Model), model }
             };
-            var html = renderer.RenderComponent<NestedComponents>(parameters);
+            var html = templater.RenderComponent<NestedComponents>(parameters);
 
             // trim leading space and trailing CRLF from output
             var actual = html.Trim();
@@ -209,47 +209,59 @@ namespace BlazorTemplater.Tests
         [TestMethod]
         public void RenderComponent_ReusingRenderer()
         {
-            // set up
-            const int a = 2;
-            const int b = 3;
-            const int c = a + b;
-            string expected1 = $"<p>If you add {a} and {b} you get {c}</p>";
+            // create a templater and register an ITestService. The service adds values
+            var templater = new Templater();
+            templater.AddService<ITestService>(new TestService());
 
-            const int x = 456;
-            const int y = 123;
-            const int z = x + y;
-            string expected2 = $"<p>If you add {x} and {y} you get {z}</p>";
-
-            // create a renderer and register an ITestService. The service adds values
-            var renderer = new BlazorTemplater();
-            renderer.AddService<ITestService>(new TestService());
-
-            var parameters1 = new Dictionary<string, object>()
+            // Render the component 100 times
+            const int count = 100;
+            for (int a = 1; a <= count; a++)
             {
-                { nameof(ServiceInjection.A), a },
-                { nameof(ServiceInjection.B), b }
-            };
+                // set up
+                const int b = 3;
+                int c = a + b;
+                string expected = $"<p>If you add {a} and {b} you get {c}</p>";
 
-            // new parameters
-            var parameters2 = new Dictionary<string, object>()
-            {
-                { nameof(ServiceInjection.A), x },
-                { nameof(ServiceInjection.B), y }
-            };
+                var parameters = new Dictionary<string, object>()
+                {
+                    { nameof(ServiceInjection.A), a },
+                    { nameof(ServiceInjection.B), b }
+                };
 
-            // render both components
-            var actual1 = renderer.RenderComponent<ServiceInjection>(parameters1);
-            var actual2 = renderer.RenderComponent<ServiceInjection>(parameters2);
+                // render both components
+                var actual = templater.RenderComponent<ServiceInjection>(parameters);
 
-            Console.WriteLine(actual1);
-            Console.WriteLine(actual2);
-
-
-            Assert.AreEqual(expected1, actual1);
-            Assert.AreEqual(expected2, actual2);
-
+                Console.WriteLine(actual);
+                Assert.AreEqual(expected, actual);
+            }
         }
 
         #endregion
+
+        #region Code-Behind Test
+
+        /// <summary>
+        /// Test a simple component with no parameters
+        /// </summary>
+        [TestMethod]
+        public void RenderComponent_CodeBehind_Test()
+        {
+            const string expected = @"<p>Yes Jon, we can use code-behind files with BlazorTemplater</p>";
+
+            var templater = new Templater();
+            var parameters = new Dictionary<string, object>()
+            {
+                { nameof(CodeBehind.App), "BlazorTemplater" },
+                { nameof(CodeBehind.Name), "Jon" }
+            };
+            var actual = templater.RenderComponent<CodeBehind>(parameters);
+
+            Console.WriteLine(actual);
+            Assert.AreEqual(expected, actual);
+        }
+
+
+        #endregion
+
     }
 }

--- a/BlazorTemplater.sln
+++ b/BlazorTemplater.sln
@@ -18,9 +18,10 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{B0E3EF40-CE74-4196-993F-D65E256F52FB}"
 	ProjectSection(SolutionItems) = preProject
 		Docs\AddRazorSupport.md = Docs\AddRazorSupport.md
+		Docs\Usage.md = Docs\Usage.md
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BlazorTemplater.ConsoleApp", "BlazorTemplater.ConsoleApp\BlazorTemplater.ConsoleApp.csproj", "{B1C3C891-8000-4AAB-AEAA-1902EDF6D3B0}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BlazorTemplater.ConsoleApp", "BlazorTemplater.ConsoleApp\BlazorTemplater.ConsoleApp.csproj", "{B1C3C891-8000-4AAB-AEAA-1902EDF6D3B0}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/BlazorTemplater/BlazorTemplater.csproj
+++ b/BlazorTemplater/BlazorTemplater.csproj
@@ -9,10 +9,9 @@
     <PackageProjectUrl>https://github.com/conficient/BlazorTemplater</PackageProjectUrl>
     <RepositoryUrl>https://github.com/conficient/BlazorTemplater</RepositoryUrl>
     <PackageTags>Blazor RazorComponents HTML Email Templating</PackageTags>
-    <Version>1.0.0</Version>
-    <PackageReleaseNotes>Initial Version</PackageReleaseNotes>
+    <Version>1.1.0</Version>
+    <PackageReleaseNotes>Breaking change: renamed BlazorTemplater class to Templater</PackageReleaseNotes>
   </PropertyGroup>
-
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components" Version="3.1.14" />

--- a/BlazorTemplater/Templater.cs
+++ b/BlazorTemplater/Templater.cs
@@ -8,14 +8,14 @@ using System.Collections.Generic;
 namespace BlazorTemplater
 {
     /// <summary>
-    /// Rendering 'host' that supports service injection
+    /// Templating host that supports service injection and rendering
     /// </summary>
-    public class BlazorTemplater
+    public class Templater
     {
         /// <summary>
         /// Ctor
         /// </summary>
-        public BlazorTemplater()
+        public Templater()
         {
             // define a lazy service provider
             _serviceProvider = new Lazy<IServiceProvider>(() =>
@@ -31,26 +31,37 @@ namespace BlazorTemplater
             });
         }
 
+        /// <summary>
+        /// Lazy service collection instance
+        /// </summary>
         private readonly ServiceCollection _serviceCollection = new ServiceCollection();
+
+        /// <summary>
+        /// Lazy HtmlRenderer instance
+        /// </summary>
         private readonly Lazy<HtmlRenderer> _renderer;
+
+        /// <summary>
+        /// Lazy ServiceProvider instance
+        /// </summary>
         private readonly Lazy<IServiceProvider> _serviceProvider;
 
         /// <summary>
-        /// Services provided by DI
+        /// Services provided by Dependency Injection
         /// </summary>
         public IServiceProvider Services => _serviceProvider.Value;
 
         /// <summary>
-        /// Gets lazy renderer
+        /// Gets Renderer
         /// </summary>
         private HtmlRenderer Renderer => _renderer.Value;
 
         /// <summary>
         /// Add a service for injection - do this before rendering
         /// </summary>
-        /// <typeparam name="TContract"></typeparam>
-        /// <typeparam name="TImplementation"></typeparam>
-        /// <param name="implementation"></param>
+        /// <typeparam name="TContract">The interface/contract</typeparam>
+        /// <typeparam name="TImplementation">The implementation type</typeparam>
+        /// <param name="implementation">Instance to return</param>
         public void AddService<TContract, TImplementation>(TImplementation implementation) where TImplementation : TContract
         {
             if (_renderer.IsValueCreated)
@@ -63,8 +74,8 @@ namespace BlazorTemplater
         /// <summary>
         /// Add a service with implementation
         /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="implementation"></param>
+        /// <typeparam name="T">Type of service</typeparam>
+        /// <param name="implementation">Instance to return</param>
         public void AddService<T>(T implementation)
             => AddService<T, T>(implementation);
 

--- a/Docs/Usage.md
+++ b/Docs/Usage.md
@@ -1,0 +1,65 @@
+# Usage
+
+### Creating Templates
+
+Create templates using `.razor` components in your code, e.g. `MyComponent.razor`. Razor Components compile into classes so they can be referenced using the class name (normally the same as filename). Refer to [the official docs](https://docs.microsoft.com/en-us/aspnet/core/blazor/components) if you need more guidance.
+
+They default to the namespace of the folder they are in, but you can override this with the [`@namespace` directive](https://docs.microsoft.com/en-us/aspnet/core/blazor/components/?view=aspnetcore-5.0#namespaces).
+
+Create an instance of the `Templater` class. This is a rendering host that also acts as a service container. This instance can be reused multiple times provided the services to be injected are the same.
+
+Use the `.RenderComponent<Type>(..)` method to generate the HTML.
+
+#### Simple Render
+To render a component which does not need any parameters set, use the `.RenderComponent<TComponent>()` method, where `TComponent` is the type generated for the Razor Component.
+```c#
+var templater = new Templater();
+var html = templater.RenderComponent<MyComponent>();
+```
+#### Setting Component Parameters
+
+Parameters are passed to the `Renderer` as an `IDictionary<string, object>`. These are passed when you call `RenderComponent`:
+```c#
+var parameters = new Dictionary<string, object>()
+    {
+        { nameof(MyComponent.Model), myModel }
+    };
+var html = templater.RenderComponent<MyComponent>(parameters);
+```
+You can use the string name of a parameter if you wish:
+```
+var parameters = new Dictionary<string, object>()
+    {
+        { "Model", myModel }
+    };
+```
+although this isn't recommended as the code will be invalid if the parameter in the component is renamed. Using `nameof(Component.ParameterName)` will ensure that a rename will update your rendering code.
+
+#### Injecting Service Dependencies
+
+You can use [Dependency Injection](https://docs.microsoft.com/en-us/aspnet/core/blazor/fundamentals/dependency-injection) in Razor Components. The `Templater` class acts as a dependency injection (DI) service provider in this respect. To register services, use the `.AddService()` methods:
+
+```c#
+var templater = new Templater();
+templater.AddService<ITestService>(new TestService());
+```
+
+You can inject services in your Razor Components as you would in a UI component, using the `@inject [type] [variable]` statement in the component, e.g.
+```c#
+@inject ITestService testService
+```
+The service can then be referenced in the component as required:
+```c#
+@testService.Add(A,B)
+```
+
+In ASP.NET Core it's possible to use DI to chain dependencies via constructor injection. That isn't supported here and you need to instantiate your services manually.
+
+#### Errors
+
+Razor Components are classes that execute code, so if there is an error in your component, `RenderComponent` will throw an exception. A common error is not setting parameters resulting in a `NullReferenceException`.
+
+### Supported Features
+
+#### Nesting Components
+Razor Components can be nested so you can use a more structured approach to designing your layout. 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ A library that generates HTML (e.g. for emails) from [Razor Components](https://
 #### Examples
 Using the library is simple:
 ```c#
-var renderer = new BlazorTemplater();
-var html = renderer.RenderComponent<MyComponent>();
+var templater = new Templater();
+var html = templater.RenderComponent<MyComponent>();
 ```
 This renders the `MyComponent` component as HTML.
 
@@ -15,13 +15,13 @@ This renders the `MyComponent` component as HTML.
 
 You can also set parameters on a component, e.g.
 ```c#
-var renderer = new BlazorTemplater();
+var templater = new Templater();
 var myModel = new Model() { Value = "test" };
 var parameters = new Dictionary<string, object>()
     {
         { nameof(MyComponent.Model), myModel }
     };
-var html = renderer.RenderComponent<MyComponent>(parameters);
+var html = templater.RenderComponent<MyComponent>(parameters);
 ```
 The dictionary is used to pass parameter values the component by name. Using `nameof()` 
 instead of hard-coding a string is recommended to avoid code changes causing errors.
@@ -30,14 +30,20 @@ instead of hard-coding a string is recommended to avoid code changes causing err
 
 You can also use dependency injection:
 ```c#
-var renderer = new BlazorTemplater();
-renderer.AddService<ITestService>(new TestService());
-var html = renderer.RenderComponent<MyComponent>();
+var templater = new Templater();
+templater.AddService<ITestService>(new TestService());
+var html = templater.RenderComponent<MyComponent>();
 ```
 
 ## Getting Started
 
 Add the `BlazorTemplater` NUGET package to your library.
+
+### Usage
+
+Create an instance of the `Templater` class, and use `.RenderComponent<TComponent>()` to create the HTML.
+
+See the [Usage](Docs/usage) page for more detailed usage guidance.
 
 ### Supported Project Types
 
@@ -48,13 +54,7 @@ Add the `BlazorTemplater` NUGET package to your library.
  - .NET 5 
  - .NET 6
 
-Libraries or applications using `BlazorTemplator` need to have the **Razor SDK** enabled to provide compilation and intellisense for `.razor` files. If you have an existing .NET Standard class library that does not have Razor Component support, follow [this guide](Docs/AddRazorSupport) to upgrade the library. I did have issues retrofitting Razor support into the .NET Core 3.1 unit test app, so I moved the `.razor` classes into a .NET Standard library `BlazorTemplater.Library`. This should not be an issue for a Blazor WASM or Blazor Server application using .NET Core 3.1 since they already support.
-
-### Usage
-
-Create an instance of the `BlazorTemplater` class. This instance can be reused multiple times provided the services to be injected are the same.
-
-To render a component which does not need any parameters set, use the `.RenderComponent<TComponent>()` method, where `TComponent` is the type generated for the Razor Component.
+Libraries or applications using `BlazorTemplator` need to have the **Razor SDK** enabled to provide compilation and intellisense for `.razor` files. If you have an existing .NET Standard class library that does not have Razor Component support, follow [this guide](Docs/AddRazorSupport) to upgrade the library. I did have issues retrofitting Razor support into the .NET Core 3.1 unit test app, so I moved the `.razor` classes into a .NET Standard library `Templater.Library`. This should not be an issue for a Blazor WASM or Blazor Server application using .NET Core 3.1 since they already support.
 
 ## Background
 
@@ -77,12 +77,20 @@ BlazorRenderer supports using:
  - Setting `[Parameters]` on Components
  - Injecting service sependencies via `.AddService<..>`
  - Nested Components
+ - [Code-behind Components](https://docs.microsoft.com/en-us/aspnet/core/blazor/components/?view=aspnetcore-5.0#partial-class-support)
  
 ### Limitations
 
 The following are not supported/tested:
    - EventCallbacks
    - Rerendering
+   - CSS and CSS isolation
+
+#### CSS and Html Emails
+
+CSS support in HTML emails is a complicated area. Many email clients (Outlook, GMail, Hotmail etc) have differing levels of what is supported. You can't often reference an external CSS file from the email as external references are often blocked.
+
+A good idea is to use a utility library to pre-process and inline the CSS before creating the email body. A good example of this is [PreMailer.NET](https://github.com/milkshakesoftware/PreMailer.Net).
 
 ## Credits and Acknowledgements
 
@@ -92,4 +100,8 @@ This was never developed into a functioning product or library. For unit testing
 
 ### Version History
 
-1.0.0   Inital Release (to Nuget)
+| Version  | Changes |
+| -------- |-----------|
+| v1.0.0   | Inital Release (to Nuget) |
+| v1.1.0   | **Breaking change**: renamed `BlazorTemplater` class to `Templater` [#4](https://github.com/conficient/BlazorTemplater/issues/4) |
+


### PR DESCRIPTION
Renames `BlazorTemplater` class to `Templater`. Naming the class the same as the namespace was not a good idea.

Also updated documentation and added more tests, .e.g for code-behind