### PR TITLE
Support multi-targeting for net-std/net5 - fixes #12

### DIFF
--- a/.github/workflows/dotnet-core-pr.yml
+++ b/.github/workflows/dotnet-core-pr.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.x
+        dotnet-version: 5.0.x
     - name: Install dependencies
       run: dotnet restore
     - name: Build

--- a/.github/workflows/dotnet-core-pr.yml
+++ b/.github/workflows/dotnet-core-pr.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.x
+        dotnet-version: '3.1.x'
     - name: Install dependencies
       run: dotnet restore
     - name: Build

--- a/.github/workflows/dotnet-core-pr.yml
+++ b/.github/workflows/dotnet-core-pr.yml
@@ -11,10 +11,14 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Setup .NET Core
+    - name: Setup .NET Core 3.1
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '3.1.x'
+        dotnet-version: 3.1.x
+    - name: Setup .NET 5
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 5.0.x
     - name: Install dependencies
       run: dotnet restore
     - name: Build

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.x
+        dotnet-version: 5.0.x
     - name: Install dependencies
       run: dotnet restore
     - name: Build

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.x
+        dotnet-version: 3.1.x
     - name: Install dependencies
       run: dotnet restore
     - name: Build

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -11,10 +11,14 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Setup .NET Core
+    - name: Setup .NET Core 3.1
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 3.1.x
+    - name: Setup .NET 5
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 5.0.x
     - name: Install dependencies
       run: dotnet restore
     - name: Build

--- a/BlazorTemplater/BlazorTemplater.csproj
+++ b/BlazorTemplater/BlazorTemplater.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk.Razor">
+﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
     <RazorLangVersion>3.0</RazorLangVersion>
     <Authors>conficient</Authors>
     <Company>conficient</Company>
@@ -9,13 +9,16 @@
     <PackageProjectUrl>https://github.com/conficient/BlazorTemplater</PackageProjectUrl>
     <RepositoryUrl>https://github.com/conficient/BlazorTemplater</RepositoryUrl>
     <PackageTags>Blazor RazorComponents HTML Email Templating</PackageTags>
-    <Version>1.1.1</Version>
-    <PackageReleaseNotes>Breaking change: renamed BlazorTemplater class to Templater</PackageReleaseNotes>
+    <Version>1.2.0</Version>
+    <PackageReleaseNotes>Fixed issue with using library in .NET 5.0</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components" Version="3.1.14" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="3.1.14" />
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="3.1.14" Condition="'$(TargetFramework)' == 'netstandard2.0'"/>
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="3.1.14" Condition="'$(TargetFramework)' == 'netstandard2.0'"/>
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="5.0.5" Condition="'$(TargetFramework)' != 'netstandard2.0'" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="5.0.5" Condition="'$(TargetFramework)' != 'netstandard2.0'" />
+    
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Amended target frameworks to create separate versions for NET 5.0 and NetStandard 2.0, to account for change of ComponentId from a field to a property.