### PR TITLE
Added non-generic render option to Templater - enables static sites

### DIFF
--- a/BlazorTemplater.Tests/Templater_Tests.cs
+++ b/BlazorTemplater.Tests/Templater_Tests.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 namespace BlazorTemplater.Tests
 {
     [TestClass]
-    public class BlazorTemplater_Tests
+    public class Templater_Tests
     {
         #region Ctor
 
@@ -31,6 +31,25 @@ namespace BlazorTemplater.Tests
 
             var templater = new Templater();
             var actual = templater.RenderComponent<Simple>();
+
+            Console.WriteLine(actual);
+            Assert.AreEqual(expected, actual);
+        }
+
+        #endregion Simple render
+        
+        #region Non-Generic Simple render
+
+        /// <summary>
+        /// Test a simple component with no parameters
+        /// </summary>
+        [TestMethod]
+        public void RenderComponent_Simple_TestNonGeneric()
+        {
+            const string expected = @"<b>Jan 1st is 2021-01-01</b>";
+
+            var templater = new Templater();
+            var actual = templater.RenderComponent(typeof(Simple));
 
             Console.WriteLine(actual);
             Assert.AreEqual(expected, actual);

--- a/BlazorTemplater.sln
+++ b/BlazorTemplater.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.0.31606.5
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31624.102
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "solution", "solution", "{C0365D75-5C0A-4E88-BC0F-FF595B731B6B}"
 	ProjectSection(SolutionItems) = preProject
@@ -19,6 +19,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{B0E3EF40-C
 	ProjectSection(SolutionItems) = preProject
 		Docs\AddRazorSupport.md = Docs\AddRazorSupport.md
 		Docs\Layouts.md = Docs\Layouts.md
+		Docs\Templater.md = Docs\Templater.md
 		Docs\Usage.md = Docs\Usage.md
 	EndProjectSection
 EndProject

--- a/BlazorTemplater/BlazorTemplater.csproj
+++ b/BlazorTemplater/BlazorTemplater.csproj
@@ -9,8 +9,8 @@
     <PackageProjectUrl>https://github.com/conficient/BlazorTemplater</PackageProjectUrl>
     <RepositoryUrl>https://github.com/conficient/BlazorTemplater</RepositoryUrl>
     <PackageTags>Blazor RazorComponents HTML Email Templating</PackageTags>
-    <Version>1.4.0</Version>
-    <PackageReleaseNotes>Added support for Layouts</PackageReleaseNotes>
+    <Version>1.4.1</Version>
+    <PackageReleaseNotes>Added ability to render by Type</PackageReleaseNotes>
     <LangVersion>Latest</LangVersion>
   </PropertyGroup>
 

--- a/Docs/Templater.md
+++ b/Docs/Templater.md
@@ -1,12 +1,24 @@
 # Templater 
 
-The `Templater` class renders the component. It is superceded by `ComponentRenderer` but is used by this, and retained for backward compatibility.
+The `Templater` class renders the component. It is superceded by `ComponentRenderer` but is used by this, and retained for backward compatibility. It also supports a non-generic `RenderComponent` method so is able to render from a `Type` provided that type implements `IComponent`.
 
 ```c#
 var templater = new Templater();
 var html = templater.RenderComponent<MyComponent>();
 ```
 This renders the `MyComponent` component as HTML.
+
+** Non-Generic method **
+
+The `Templater` from v1.4.1 supports a non-generic `RenderComponent()` overload using the type of a component.
+
+```c#
+var componentType = typeof(MyComponent);
+var templater = new Templater();
+var html = templater.RenderComponent(componentType);
+```
+
+This feature was added as it enables the option to create static websites from a set of `RazorComponents` using reflection. See #15
 
 **Parameters**
 


### PR DESCRIPTION
Leading on from #15 it would be possible to create static sites and use reflection, if the `Templater` had a non-generic method. This update adds that option.