### PR TITLE
Inject an IServiceProvider to Templater and ComponentRenderer

### DIFF
--- a/BlazorTemplater.Tests/ComponentRenderer_Tests.cs
+++ b/BlazorTemplater.Tests/ComponentRenderer_Tests.cs
@@ -1,4 +1,5 @@
 ﻿using BlazorTemplater.Library;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 
@@ -144,6 +145,30 @@ namespace BlazorTemplater.Tests
             // fluent ComponentBuilder approach
             var actual = new ComponentRenderer<ServiceInjection>()
                 .AddService<ITestService>(new TestService())
+                .Set(p => p.A, a)
+                .Set(p => p.B, b)
+                .Render();
+
+            Console.WriteLine(actual);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void AddServiceProvider_Test()
+        {
+            // set up
+            const int a = 2;
+            const int b = 3;
+            const int c = a + b;
+            string expected = $"<p>If you add {a} and {b} you get {c}</p>";
+
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddSingleton<ITestService>(new TestService());
+            var serviceProvider = serviceCollection.BuildServiceProvider();
+
+            // fluent ComponentBuilder approach
+            var actual = new ComponentRenderer<ServiceInjection>()
+                .AddServiceProvider(serviceProvider)
                 .Set(p => p.A, a)
                 .Set(p => p.B, b)
                 .Render();

--- a/BlazorTemplater.Tests/Templater_Tests.cs
+++ b/BlazorTemplater.Tests/Templater_Tests.cs
@@ -1,4 +1,5 @@
 using BlazorTemplater.Library;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
@@ -172,6 +173,36 @@ namespace BlazorTemplater.Tests
             // create a templater and register an ITestService. The service adds values
             var templater = new Templater();
             templater.AddService<ITestService>(new TestService());
+
+            var parameters = new Dictionary<string, object>()
+            {
+                { nameof(ServiceInjection.A), a },
+                { nameof(ServiceInjection.B), b }
+            };
+            var actual = templater.RenderComponent<ServiceInjection>(parameters);
+
+            Console.WriteLine(actual);
+            Assert.AreEqual(expected, actual);
+        }
+
+        //Test that services from injected service providers works
+        [TestMethod]
+        public void AddServiceProvider_TestInstanceMethod()
+        {
+            // set up
+            const int a = 2;
+            const int b = 3;
+            const int c = a + b;
+            string expected = $"<p>If you add {a} and {b} you get {c}</p>";
+
+
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddSingleton<ITestService>(new TestService());
+            var serviceProvider = serviceCollection.BuildServiceProvider();
+
+            // create a templater and register an ITestService. The service adds values
+            var templater = new Templater();
+            templater.AddServiceProvider(serviceProvider);
 
             var parameters = new Dictionary<string, object>()
             {

--- a/BlazorTemplater/BlazorTemplater.csproj
+++ b/BlazorTemplater/BlazorTemplater.csproj
@@ -15,8 +15,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components" Version="3.1.14" Condition="'$(TargetFramework)' == 'netstandard2.0'"/>
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="3.1.14" Condition="'$(TargetFramework)' == 'netstandard2.0'"/>
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="3.1.14" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="3.1.14" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
     <PackageReference Include="Microsoft.AspNetCore.Components" Version="5.0.5" Condition="'$(TargetFramework)' != 'netstandard2.0'" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="5.0.5" Condition="'$(TargetFramework)' != 'netstandard2.0'" />
     

--- a/BlazorTemplater/ComponentRenderer.cs
+++ b/BlazorTemplater/ComponentRenderer.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
@@ -118,6 +119,12 @@ namespace BlazorTemplater
         public ComponentRenderer<TComponent> UseLayout<TLayout>() where TLayout : LayoutComponentBase
         {
             templater.UseLayout<TLayout>();
+            return this;
+        }
+
+        public ComponentRenderer<TComponent> AddServiceProvider(ServiceProvider serviceProvider)
+        {
+            templater.AddServiceProvider(serviceProvider);
             return this;
         }
 

--- a/BlazorTemplater/ServiceProviderComposition/ComposableServiceBuilder.cs
+++ b/BlazorTemplater/ServiceProviderComposition/ComposableServiceBuilder.cs
@@ -1,0 +1,42 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace BlazorTemplater.ServiceProviderComposition
+{
+
+    /// <summary>
+    /// a service builder able to create a service provider that can resolve services form a core service provider or from additional ones
+    /// </summary>
+    internal class ComposableServiceBuilder
+    {
+        private readonly IServiceProvider coreServiceProvider;
+        private readonly IEnumerable<IServiceProvider> composingProviders;
+
+        /// <summary>
+        /// creates a composables service builder
+        /// </summary>
+        /// <param name="coreServiceProvider">the base core service provider</param>
+        /// <param name="composingProviders">additional service provider to query one after the other</param>
+        public ComposableServiceBuilder(IServiceProvider coreServiceProvider, IEnumerable<IServiceProvider> composingProviders = null)
+        {
+            this.coreServiceProvider = coreServiceProvider;
+            this.composingProviders = composingProviders;
+        }
+
+        /// <summary>
+        /// build a new service provider
+        /// </summary>
+        /// <returns>the returned service provider is the coreServiceProvider if no composingProviders are passed in the constructor, otherwise a ComposingServiceProvider for all the service providers and scopes will be created </returns>
+        public IServiceProvider Build()
+        {
+            if (composingProviders is IEnumerable<IServiceProvider> composingServiceProviders)
+            {
+                var scopes = composingServiceProviders.Select(sp => sp.CreateScope());
+                return new ComposingServiceProvider(coreServiceProvider, scopes);
+            }
+            return coreServiceProvider;
+        }
+    }
+}

--- a/BlazorTemplater/ServiceProviderComposition/ComposableServiceCollection.cs
+++ b/BlazorTemplater/ServiceProviderComposition/ComposableServiceCollection.cs
@@ -1,0 +1,95 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BlazorTemplater.ServiceProviderComposition
+{
+    /// <summary>
+    /// Enables the composition of existing service provider on a service collection
+    /// </summary>
+    internal class ComposableServiceCollection : ServiceCollection, ICollection<IServiceProvider>, IEnumerable<IServiceProvider>, IList<IServiceProvider>
+    {
+        private readonly IList<IServiceProvider> _serviceProvider = new List<IServiceProvider>();
+
+        IServiceProvider IList<IServiceProvider>.this[int index] { get => _serviceProvider[index]; set => _serviceProvider[index] = value; }
+
+        /// <summary>
+        /// Allows to add an existing service provider to the the reslution ability of the current service collection
+        /// </summary>
+        /// <remarks>Composed service providers are queryed in the order they are added</remarks>
+        /// <param name="item">An additional service provider to use to resolve services, all the services from the composed service provider will be available for the resolution</param>
+        public void Add(IServiceProvider item)
+        {
+            _serviceProvider.Add(item);
+        }
+
+        /// <summary>
+        /// clears the collection of services and service providers
+        /// </summary>
+        public new void Clear()
+        {
+            base.Clear();
+            _serviceProvider.Clear();
+        }
+
+        /// <summary>
+        /// check if the service provider is included in the collection
+        /// </summary>
+        /// <param name="item">the item to check</param>
+        /// <returns>true if the item is in the collection of service providers, false otherwise</returns>
+        public bool Contains(IServiceProvider item)
+        {
+            return _serviceProvider.Contains(item);
+        }
+
+        /// <summary>
+        /// copy the service providers to an array
+        /// </summary>
+        /// <param name="array">target array to fill</param>
+        /// <param name="arrayIndex">index to use as start</param>
+        public void CopyTo(IServiceProvider[] array, int arrayIndex)
+        {
+            _serviceProvider.CopyTo(array, arrayIndex);
+        }
+
+        /// <summary>
+        /// retutns the index of the searched item
+        /// </summary>
+        /// <param name="item">item to search</param>
+        /// <returns>the index of the searched item if present -1 otherwise</returns>
+        public int IndexOf(IServiceProvider item)
+        {
+            return _serviceProvider.IndexOf(item);
+        }
+
+        /// <summary>
+        /// inserts an item at the given idex
+        /// </summary>
+        /// <param name="index">index of the inserted item after the insertion</param>
+        /// <param name="item">item to insert</param>
+        public void Insert(int index, IServiceProvider item)
+        {
+            _serviceProvider.Insert(index, item);
+        }
+
+        /// <summary>
+        /// removes a service provider from the list of service provider used for the resolution
+        /// </summary>
+        /// <param name="item">item to remove</param>
+        /// <returns>true if the item was present and therefore removed, false otherwise</returns>
+        public bool Remove(IServiceProvider item)
+        {
+            return _serviceProvider.Remove(item);
+        }
+
+        /// <summary>
+        /// obtains en enumerators of all the service providers
+        /// </summary>
+        /// <returns>an enumerator of all the service providers in the collection</returns>
+        IEnumerator<IServiceProvider> IEnumerable<IServiceProvider>.GetEnumerator()
+        {
+            return _serviceProvider.GetEnumerator();
+        }
+    }
+}

--- a/BlazorTemplater/ServiceProviderComposition/ComposableServiceProviderFactory.cs
+++ b/BlazorTemplater/ServiceProviderComposition/ComposableServiceProviderFactory.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace BlazorTemplater.ServiceProviderComposition
+{
+    /// <summary>
+    /// provides a way to create a service provider able to use other service provider, if the service collection is also an IEnumerable<IServiceProvider> 
+    /// </summary>
+    internal class ComposableServiceProviderFactory : IServiceProviderFactory<ComposableServiceBuilder>
+    {
+
+        /// <summary>
+        /// create a builder for a service collection
+        /// </summary>
+        /// <param name="services">a collection of services, if it is also a collection of service providers then the generated builder will produce a ComposingServiceProvider</param>
+        /// <returns>a builder for the service collection</returns>
+        public ComposableServiceBuilder CreateBuilder(IServiceCollection services)
+        {
+            var coreServiceProvider = services.BuildServiceProvider();
+            if (services is IEnumerable<IServiceProvider> composingServiceProviders)
+            {
+                return new(coreServiceProvider, composingServiceProviders);
+            }
+            return new(coreServiceProvider);
+        }
+        
+        /// <summary>
+        /// produces a service provider  for the composable service builder
+        /// </summary>
+        /// <param name="containerBuilder">the container of services and service provider to use as a source for the creation of the serviceprovider</param>
+        /// <returns>a service provider that will be able to resolve services from the service collection or from one of the composed service provider</returns>
+        public IServiceProvider CreateServiceProvider(ComposableServiceBuilder containerBuilder)
+        {
+            return containerBuilder.Build();
+        }
+    }
+}

--- a/BlazorTemplater/ServiceProviderComposition/ComposingServiceProvider.cs
+++ b/BlazorTemplater/ServiceProviderComposition/ComposingServiceProvider.cs
@@ -1,0 +1,55 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace BlazorTemplater.ServiceProviderComposition
+{
+    /// <summary>
+    /// A service provider able to resolve services from a core service provider or from a service scope list
+    /// </summary>
+    internal class ComposingServiceProvider : IServiceProvider, IDisposable
+    {
+        private IServiceProvider _coreServiceProvider;
+        private IEnumerable<IServiceScope> _scopes;
+
+
+        /// <summary>
+        /// Creates a composing service provider
+        /// </summary>
+        /// <param name="coreServiceProvider">the base service provider used first</param>
+        /// <param name="scopes">a series of additional service scope to use une after other to perform additional resolutions</param>
+        public ComposingServiceProvider(IServiceProvider coreServiceProvider, IEnumerable<IServiceScope> scopes)
+        {
+            _coreServiceProvider = coreServiceProvider;                      
+            _scopes = new List<IServiceScope>(scopes);  //force enumeration so to not need to re-execute the enumerator each time later in the foreach of GetService
+            //HINT: NOTE: do not use scopes.ToList() but use new List<IServiceScope>(scopes) instead because .ToList will not work as the real implementation of "scope"
+            //is an object that implments both IEnumerable<IServiceDescriptor> and IEnumerable<IServiceScope> 
+            //the .ToList will default to the IEnumerable<IServiceScope>.GetEnumerator and will result in copying nothing.
+            //instead the new List<IServiceScope> will use the correct override of the GetEnumerator to extract the elements
+        }
+
+        /// <summary>
+        /// obtain a service of the given type
+        /// </summary>
+        /// <param name="serviceType">the type to search and instantiate</param>
+        /// <returns>an instance of the searched type fromthe core service provider, or form one of the additional scopes searched in order</returns>
+        public object GetService(Type serviceType)
+        {
+            if (_coreServiceProvider.GetService(serviceType) is object foundService) return foundService;
+
+            foreach (var scope in _scopes)
+            {
+                if (scope.ServiceProvider.GetService(serviceType) is object serviceFromScope) return serviceFromScope;
+            }            
+
+            return null;
+        }
+
+        //disposes all the scopes
+        public void Dispose()
+        {
+            foreach (var scope in _scopes) scope.Dispose();
+        }
+    }
+}

--- a/BlazorTemplater/Templater.cs
+++ b/BlazorTemplater/Templater.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Components;
+﻿using BlazorTemplater.ServiceProviderComposition;
+using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -17,11 +18,14 @@ namespace BlazorTemplater
         /// Ctor
         /// </summary>
         public Templater()
-        {
+        {            
+
             // define a lazy service provider
             _serviceProvider = new Lazy<IServiceProvider>(() =>
             {
-                return _serviceCollection.BuildServiceProvider();
+                var factory = new ComposableServiceProviderFactory();
+                return factory.CreateServiceProvider(
+                    factory.CreateBuilder(_serviceCollection));
             });
 
             // define lazy renderer
@@ -35,7 +39,7 @@ namespace BlazorTemplater
         /// <summary>
         /// Service collection instance
         /// </summary>
-        private readonly ServiceCollection _serviceCollection = new();
+        private readonly ComposableServiceCollection _serviceCollection = new();
 
         /// <summary>
         /// Lazy HtmlRenderer instance
@@ -170,6 +174,11 @@ namespace BlazorTemplater
             layout = typeof(TLayout);
         }
 
+        public void AddServiceProvider(IServiceProvider serviceProvider)
+        {
+            _serviceCollection.Add(serviceProvider);
+        }
+
         /// <summary>
         /// Sets a layout to use from a Type
         /// </summary>
@@ -225,7 +234,7 @@ namespace BlazorTemplater
         /// </summary>
         /// <param name="componentType"></param>
         /// <returns></returns>
-        private Type GetLayout(Type componentType) 
+        private Type GetLayout(Type componentType)
         {
             // Use layout override if set
             if (layout != null)


### PR DESCRIPTION
I've implemented the ability to inject an already existing IServiceProvider in the Templater, this way it is more easy to use the same dependency injection mechanism available for the application
it is still possible to add additional services to the templater that are not present in the service provider.
by extension it is also possible to add multiple service providers due to the nature of the fluent interface, in this case the services added to the templater directly will be resolved first, if not resolved, the infrastructure will try the IServiceProvider (s one by one in the order they was added).

this should help the usage of BlazorTemplater in already existing applications without the need to obtain and reload all the type to resolve, basically re-creating the startup twice,
the enviseged usage is the following
```
//serviceProvider is filled by the DI mechanism
public string MyMethod(IServiceProvider serviceProvider){
   var templater = new Templater();
   templater.AddServiceProvider(serviceProvider);
   var parameters = new Dictionary<string, object>()
            {
                { nameof(ServiceInjection.A), a },
                { nameof(ServiceInjection.B), b }
            };
   var result = templater.RenderComponent<ServiceInjection>(parameters);
   return result;
}
```