### PR TITLE
Feature async render

### DIFF
--- a/BlazorTemplater.Library/AsyncRender.razor
+++ b/BlazorTemplater.Library/AsyncRender.razor
@@ -1,0 +1,12 @@
+﻿<h3>AsyncRender Text: @Text</h3>
+
+@code {
+    public string Text { get; set; } = "Original value";
+
+    protected override async Task OnInitializedAsync()
+    {
+        await Task.Delay(500);
+        Text = "Async value";
+        await base.OnInitializedAsync();
+    }
+}

--- a/BlazorTemplater.Tests/ComponentRenderer_Tests.cs
+++ b/BlazorTemplater.Tests/ComponentRenderer_Tests.cs
@@ -2,6 +2,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+using System.Threading.Tasks;
 
 namespace BlazorTemplater.Tests
 {
@@ -100,7 +101,7 @@ namespace BlazorTemplater.Tests
             // expected output
             const string expected = "<p>No model!</p>";
 
-            var html = new ComponentRenderer<Parameters>()
+            var html = new ComponentRenderer<Parameters>()                
                 .Render();
 
             // trim leading space and trailing CRLF from output
@@ -111,6 +112,24 @@ namespace BlazorTemplater.Tests
         }
 
         #endregion Parameters
+
+        #region Async render
+
+        /// <summary>
+        /// Test a async render, so the html is generated only after the async lifecycle is completed
+        /// </summary>
+        [TestMethod]
+        public async Task Async_Test()
+        {
+            const string expected = @"<h3>AsyncRender Text: Async value</h3>";
+            
+            var actual = await new ComponentRenderer<AsyncRender>().RenderAsync();
+
+            Console.WriteLine(actual);
+            Assert.AreEqual(expected, actual);
+        }
+
+        #endregion Async render
 
         #region Errors
 

--- a/BlazorTemplater.Tests/Templater_Tests.cs
+++ b/BlazorTemplater.Tests/Templater_Tests.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace BlazorTemplater.Tests
 {
@@ -136,6 +137,26 @@ namespace BlazorTemplater.Tests
         }
 
         #endregion Parameters
+
+
+        #region Async render
+
+        /// <summary>
+        /// Test a async render, so the html is generated only after the async lifecycle is completed
+        /// </summary>
+        [TestMethod]
+        public async Task RenderComponent_Async_Test()
+        {
+            const string expected = @"<h3>AsyncRender Text: Async value</h3>";
+
+            var templater = new Templater();
+            var actual = await templater.RenderComponentAsync<AsyncRender>();
+
+            Console.WriteLine(actual);
+            Assert.AreEqual(expected, actual);
+        }
+
+        #endregion Async render
 
         #region Errors
 

--- a/BlazorTemplater.sln
+++ b/BlazorTemplater.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.31624.102
+# Visual Studio Version 17
+VisualStudioVersion = 17.3.32811.315
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "solution", "solution", "{C0365D75-5C0A-4E88-BC0F-FF595B731B6B}"
 	ProjectSection(SolutionItems) = preProject

--- a/BlazorTemplater/BlazorTemplater.csproj
+++ b/BlazorTemplater/BlazorTemplater.csproj
@@ -9,8 +9,8 @@
     <PackageProjectUrl>https://github.com/conficient/BlazorTemplater</PackageProjectUrl>
     <RepositoryUrl>https://github.com/conficient/BlazorTemplater</RepositoryUrl>
     <PackageTags>Blazor RazorComponents HTML Email Templating</PackageTags>
-    <Version>1.5.0</Version>
-    <PackageReleaseNotes>Added ability to inject an entire IServiceProvider</PackageReleaseNotes>
+    <Version>1.6.0</Version>
+    <PackageReleaseNotes>Added ability to await the completion of the async lifecycle before generating the output html so to include all possible updates from the async methods</PackageReleaseNotes>
     <LangVersion>Latest</LangVersion>
   </PropertyGroup>
 

--- a/BlazorTemplater/ComponentRenderer.cs
+++ b/BlazorTemplater/ComponentRenderer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Reflection;
+using System.Threading.Tasks;
 
 namespace BlazorTemplater
 {
@@ -153,6 +154,16 @@ namespace BlazorTemplater
         {
             // renders the component and returns the markup HTML
             return templater.RenderComponent<TComponent>(parameters);
+        }
+
+        /// <summary>
+        /// Render the component to HTML waiting all the async lifecycle to complete
+        /// </summary>
+        /// <returns></returns>
+        public Task<string> RenderAsync()
+        {
+            // renders the component and returns the markup HTML
+            return templater.RenderComponentAsync<TComponent>(parameters);
         }
     }
 }

--- a/BlazorTemplater/ContainerComponent.cs
+++ b/BlazorTemplater/ContainerComponent.cs
@@ -72,6 +72,14 @@ namespace BlazorTemplater
                     builder.CloseComponent();
                 });
             });
+            
+        }
+
+        public Task RenderComponentUnderTestAsync(Type componentType, ParameterView parameters)
+        {
+            RenderComponentUnderTest(componentType, parameters);
+            return _renderer.AwaitAllPendingTasks();
+
         }
     }
 }

--- a/BlazorTemplater/HtmlRenderer.cs
+++ b/BlazorTemplater/HtmlRenderer.cs
@@ -71,5 +71,10 @@ namespace BlazorTemplater
                 ExceptionDispatchInfo.Capture(_unhandledException).Throw();
             }
         }
+
+        internal Task AwaitAllPendingTasks()
+        {
+            return NextRender;
+        }
     }
 }

--- a/BlazorTemplater/RenderedComponent.cs
+++ b/BlazorTemplater/RenderedComponent.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Components;
+using System.Threading.Tasks;
 
 namespace BlazorTemplater
 {
@@ -32,6 +33,15 @@ namespace BlazorTemplater
         internal void SetParametersAndRender(ParameterView parameters)
         {
             _containerTestRootComponent.RenderComponentUnderTest(
+                typeof(TComponent), parameters);
+            var foundTestComponent = _containerTestRootComponent.FindComponentUnderTest();
+            _testComponentId = foundTestComponent.Item1;
+            _testComponentInstance = (TComponent)foundTestComponent.Item2;
+        }
+
+        internal async Task SetParametersAndRenderAsync(ParameterView parameters)
+        {
+            await _containerTestRootComponent.RenderComponentUnderTestAsync(
                 typeof(TComponent), parameters);
             var foundTestComponent = _containerTestRootComponent.FindComponentUnderTest();
             _testComponentId = foundTestComponent.Item1;

--- a/README.md
+++ b/README.md
@@ -205,4 +205,6 @@ This was never developed into a functioning product or library. For unit testing
 | v1.2.0   | Added multi-targetting for .NET Std/.NET 5 to fix bug [#12](https://github.com/conficient/BlazorTemplater/issues/12) |
 | v1.3.0   | Added `ComponentRenderer<T>` for fluent interface and typed parameter setting |
 | v1.4.0   | Added support for Layouts |
+| v1.5.0   | Added support already existing IServiceProvider |
+| v1.6.0   | Added support AsyncRender |
 


### PR DESCRIPTION

This is my proposed solution to [this issue](https://github.com/conficient/BlazorTemplater/issues/32)
it was independently developed from the [other PR](https://github.com/conficient/BlazorTemplater/pull/30) which I've noticed exist only after the facts :( sorry

This solution leverages on the already existing NextRender task without introducing additional synchronization mechanisms like semaphores.
As said in the above mentioned issue, the solution have a little of code duplication, there are easy way to fix it and i'm happy to apply the preferred one, let's just discuss it. options are:

- move common code in a separate method: 
Pros: easy code, Cons: the method should return more than one value => introduced a new return type with multiple properties or uses anonymous records.
- make the divergent portion of code to be called as delegate passing multiple argument to it
Pros: avoid generation of new types, Cons: less simple code, force to return Task and in case ignore it when not needed
- other...? let's discuss!
-
I probably prefer the first :)
